### PR TITLE
add parameter "query"

### DIFF
--- a/src/Parameter/Query.php
+++ b/src/Parameter/Query.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Markup\Contentful\Parameter;
+
+use Markup\Contentful\ParameterInterface;
+
+/**
+ * A parameter representing a query.
+ */
+class Query implements ParameterInterface
+{
+    const KEY = 'query';
+
+    /**
+     * @var string $query
+     */
+    private $query;
+
+    /**
+     * @param string $query
+     */
+    public function __construct($query)
+    {
+        $this->query = (string)$query;
+    }
+
+    /**
+     * The key in a query string on an API request.
+     *
+     * @return string
+     */
+    public function getKey()
+    {
+        return self::KEY;
+    }
+
+    /**
+     * The value in a query string on an API request.
+     *
+     * @return string
+     */
+    public function getValue()
+    {
+        return $this->query;
+    }
+
+    /**
+     * The name for the parameter (e.g. an EqualFilter would be called 'equal', etc)
+     *
+     * @return string
+     */
+    public function getName()
+    {
+        return self::KEY;
+    }
+}


### PR DESCRIPTION
Add a "query" as parameter for performing a full text search in API request.

Documented by contentful:
https://www.contentful.com/developers/documentation/content-delivery-api/http/#search-filter-full-text