### PR TITLE
Define a connection timeout

### DIFF
--- a/src/GuzzleOptions.php
+++ b/src/GuzzleOptions.php
@@ -41,6 +41,10 @@ class GuzzleOptions
             $instance->defaults['timeout'] = intval($options['guzzle_timeout']);
         }
 
+        if (isset($options['guzzle_connection_timeout']) && (intval($options['guzzle_connection_timeout']) > 0)) {
+            $instance->defaults['connect_timeout'] = intval($options['guzzle_connection_timeout']);
+        }
+
         return $instance;
     }
 


### PR DESCRIPTION
Although we have a `timeout` Guzzle still allows an unlimited amount of time to establish the connection at least from what Ive seen in documentation and client code base errors.