### PR TITLE
fix(cache): Dont save to cache when data invalid

### DIFF
--- a/src/Contentful.php
+++ b/src/Contentful.php
@@ -586,8 +586,12 @@ class Contentful
                 //save into cache
                 if ($api !== self::CONTENT_MANAGEMENT_API) {
                     $isSuccessResponseData = !$unavailableException && $isValidResponse;
-                    $writeCacheItem->set($responseJson);
-                    $writeCache->save($writeCacheItem);
+
+                    if ($isSuccessResponseData || $this->cacheFailResponses) {
+                        $writeCacheItem->set($responseJson);
+                        $writeCache->save($writeCacheItem);
+                    }
+
                     if (!isset($fallbackCacheItem)) {
                         /**
                          * @var CacheItemInterface $fallbackCacheItem


### PR DESCRIPTION
Following through the logic, if the cache is invalid the fallback cache is only fetched when `$this->cacheFailResponses` is true. So this change ensures that invalid responses are only cached when the variable is set.