### PR TITLE
fix(asset): fetch width+height from correct prop

### DIFF
--- a/src/AssetFile.php
+++ b/src/AssetFile.php
@@ -81,11 +81,18 @@ class AssetFile
     public function getWidth()
     {
         $details = $this->getDetails();
-        if (!isset($details['width'])) {
+
+        if (!isset($details['image'])) {
             return null;
         }
 
-        return intval($details['width']);
+        $image = $details['image'];
+
+        if (!isset($image['width'])) {
+            return null;
+        }
+
+        return intval($image['width']);
     }
 
     /**
@@ -94,11 +101,18 @@ class AssetFile
     public function getHeight()
     {
         $details = $this->getDetails();
-        if (!isset($details['height'])) {
+
+        if (!isset($details['image'])) {
             return null;
         }
 
-        return intval($details['height']);
+        $image = $details['image'];
+
+        if (!isset($image['height'])) {
+            return null;
+        }
+
+        return intval($image['height']);
     }
 
     /**


### PR DESCRIPTION
The array actually looks like this:

    -details: array:2 [▼
      "size" => 2485398
      "image" => array:2 [▼
        "width" => 3125
        "height" => 1250
      ]
    ]

So the code as it is here could never have worked - which I find really surprising as it 100% definitely worked functionally. Can only think that I accidentally pasted a bit of code incorrectly just prior to making the previous PR.