### PR TITLE
feat: drop PHP 5.x and non supported 7.x php versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,15 +3,13 @@ sudo: required
 dist: trusty
 group: edge
 php:
-    - 5.6
-    - 7.0
     - 7.1
     - 7.2
     - 7.3
 
 matrix:
     include:
-        - php: 5.6
+        - php: 7.1
           env: deps=low
 
 env:

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 contentful
 ==========
 
-Provides integrations with Contentful APIs (Delivery and Preview) for PHP 5.6+.
+Provides integrations with Contentful APIs (Delivery and Preview) for PHP 7.1+.
 
 There is an official Contentful PHP SDK now ([contentful/contentful](https://packagist.org/packages/contentful/contentful)) - so use what makes sense for you. This package has been in large-scale production for over two years now, and I am focusing on making it the fastest client available for fetching Contentful data.
 

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         }
     ],
     "require": {
-        "php": ">=5.6",
+        "php": ">=7.1",
         "guzzlehttp/guzzle": "^6.0",
         "guzzlehttp/promises": "~1.1",
         "psr/cache": "~1.0.0"


### PR DESCRIPTION
As PHP 5.6 reaches end of life next month removing 5.6 & 7.0 would allow for the codebase to be modernized to have return types and void support going forward.