### PR TITLE
Test enhancement

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: php
-sudo: required
+sudo: false
 dist: trusty
 group: edge
 php:
@@ -26,9 +26,7 @@ install:
     - if [ "$deps" = "low" ]; then composer --prefer-source --prefer-lowest --prefer-stable update; fi
 
 script:
-    - vendor/bin/phpunit -v
+    - vendor/bin/phpunit
 
 notifications:
   email: "douglas@usemarkup.com"
-
-sudo: false

--- a/tests/ContentfulTest.php
+++ b/tests/ContentfulTest.php
@@ -440,6 +440,7 @@ class ContentfulTest extends MockeryTestCase
         $contentful = $this->getContentful($spaces, array_merge($this->options, $handlerOption));
         $parameters = [new LessThanFilter(new FieldProperty('ghosts'), 6), new EqualFilter(new FieldProperty('old'), 6)];
         $this->expectException(ResourceUnavailableException::class);
+        $this->expectExceptionMessage('The entries from the space "" were unavailable.');
         $contentful->getEntries($parameters);
     }
 
@@ -466,6 +467,7 @@ class ContentfulTest extends MockeryTestCase
         $contentful = $this->getContentful($spaces, array_merge($this->options, $handlerOption, ['cache_fail_responses' => true]));
         $parameters = [new LessThanFilter(new FieldProperty('ghosts'), 6), new EqualFilter(new FieldProperty('old'), 6)];
         $this->expectException(ResourceUnavailableException::class);
+        $this->expectExceptionMessage('The entries from the space "" were unavailable.');
         $contentful->getEntries($parameters);
     }
 
@@ -534,6 +536,7 @@ class ContentfulTest extends MockeryTestCase
         $contentful = $this->getContentful($spaces, array_merge($this->options, $handlerOption, ['cache_fail_responses' => true]));
         $parameters = [new LessThanFilter(new FieldProperty('ghosts'), 6), new EqualFilter(new FieldProperty('old'), 6)];
         $this->expectException(ResourceUnavailableException::class);
+        $this->expectExceptionMessage('Contentful returned a valid response but it did not pass the provided test');
         $contentful->getEntries($parameters, null, [
             'test' => function ($builtResponse) {
                 if (!$builtResponse instanceof ResourceArray) {
@@ -687,6 +690,7 @@ class ContentfulTest extends MockeryTestCase
         $handlerOption = $this->getExplodyHandlerOption();
         $contentful = $this->getContentful($spaces, array_merge($this->options, $handlerOption, ['cache_fail_responses' => true]));
         $this->expectException(ResourceUnavailableException::class);
+        $this->expectExceptionMessage('Fetched fail response from cache for key "jskdfjhsdfk-entry↦cat".');
         $contentful->getEntry('cat');
     }
 

--- a/tests/DynamicEntryTest.php
+++ b/tests/DynamicEntryTest.php
@@ -97,7 +97,7 @@ class DynamicEntryTest extends MockeryTestCase
         $this->contentType
             ->shouldReceive('getFields')
             ->andReturn($keyedFields);
-        $this->assertTrue(isset($this->dynamicEntry['ja']));
-        $this->assertFalse(isset($this->dynamicEntry['nein']));
+        $this->assertArrayHasKey('ja', $this->dynamicEntry);
+        $this->assertArrayNotHasKey('nein', $this->dynamicEntry);
     }
 }

--- a/tests/EntryTest.php
+++ b/tests/EntryTest.php
@@ -47,8 +47,8 @@ class EntryTest extends MockeryTestCase
 
     public function testGetFieldsUsingArrayAccess()
     {
-        $this->assertTrue(isset($this->entry['foo']));
-        $this->assertFalse(isset($this->entry['unknown']));
+        $this->assertArrayHasKey('foo', $this->entry);
+        $this->assertArrayNotHasKey('unknown', $this->entry);
         $this->assertEquals('bar', $this->entry['foo']);
         $this->assertNull($this->entry['unknown']);
     }
@@ -77,7 +77,7 @@ class EntryTest extends MockeryTestCase
     public function testUnknownMethodFallsBackToFieldLookup()
     {
         $this->assertEquals('bar', $this->entry->foo());
-        $this->assertEquals(null, $this->entry->baz());
+        $this->assertNull($this->entry->baz());
     }
 
     public function testUnresolvedLinkFiltersOutFromList()

--- a/tests/Filter/MimeTypeGroupFilterTest.php
+++ b/tests/Filter/MimeTypeGroupFilterTest.php
@@ -53,6 +53,7 @@ class MimeTypeGroupFilterTest extends TestCase
     public function testCannotCreateWithUnknownValue()
     {
         $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('"unknown" is not a known MIME type group. Known types: attachment, plaintext, image, audio, video, richtext, presentation, spreadsheet, pdf_document, archive, code, markup.');
         new MimeTypeGroupFilter('unknown');
     }
 }


### PR DESCRIPTION
# Changed log
- Using the `assertArrayHasKey` to check whether key is existed in specific array.
- Using the `assertArrayNotHasKey` to check whether key is not existed in specific array.
- Using `expectExceptionMessage` to check whether the expected exception message is same as result.
- Using `assertNull` to check the expected value is null.